### PR TITLE
Add contribution banner

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -16,6 +16,11 @@ header_links:
 
 # google_site_verification:
 
+# Show a block at the bottom of the page that links to the page source, so readers can easily contribute back to the documentation.
+
+show_contribution_banner: true
+github_repo: alphagov/verify-tech-specs/
+
 # Multi-page options
 multipage_nav: true
 collapsible_nav: true


### PR DESCRIPTION
### Context

We should provide a quick way for users to propose changes to pages and to raise issues.

### Changes proposed in this pull request

Use to `show_contribution_banner: true` in the config file to show a block at the bottom of the page that links to the page source, so readers can easily contribute back to the documentation.
