### PR TITLE
BAU: Don't push everything to cloudfoundry

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,14 @@
+lib/
+logs/
+script/
+source/
+vendor/
+.github/
+.ruby-version
+.ruby-gemset
+.travis.yml
+Dockerfile
+docker-compose.yml
+Gemfile
+Gemfile.lock
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config
 /.bundle
+vendor/
 
 # Ignore the build directory
 /build


### PR DESCRIPTION
### Context

The repo contains a bunch of files that we don't want to push to
cloudfoundry when we deploy the tech specs.

For example, the vendor/ directory contains gems cached by `bundler` during the
Travis run and we don't want to push these to cloudfoundry.


### Changes proposed in this pull request

Add a `.cfignore` file to tell `cf push` to ignore certain files in the repo.

### Guidance to review